### PR TITLE
2025-07 Update

### DIFF
--- a/src/dist/bootstrap.py
+++ b/src/dist/bootstrap.py
@@ -1,0 +1,21 @@
+import os
+import subprocess
+
+def lambda_handler(event, context):
+    creds = os.environ.get("SSOSYNC_GOOGLE_CREDS_JSON")
+    if not creds:
+        print("SSOSYNC_GOOGLE_CREDS_JSON environment variable is not set.")
+        raise Exception("SSOSYNC_GOOGLE_CREDS_JSON environment variable is not set.")
+
+    print("Writing Google credentials to /tmp/credentials.json")
+    with open("/tmp/credentials.json", "w") as f:
+        f.write(creds)
+
+    print("Executing ssosync command...")
+    result = subprocess.run(["./ssosync"], capture_output=True, text=True)
+    print(result.stdout)
+    print(result.stderr)
+    print(f"ssosync exited with code {result.returncode}")
+    if result.returncode != 0:
+        raise Exception(f"ssosync exited with code {result.returncode}")
+    return {"status": "success"}

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -40,7 +40,7 @@ variable "ssosync_url_prefix" {
 variable "ssosync_version" {
   type        = string
   description = "Version of ssosync to use"
-  default     = "v2.0.2"
+  default     = "2.0.2"
 }
 
 variable "architecture" {


### PR DESCRIPTION
## what
* Fixes the non deploy-ability of this component due to AWS go1.x Lambda runtime deprecation. This is also described on #16.
* Fixes the bug of the version not having `v` prefix
* Workaround for a non previously reported bug of the **SSOSYNC_GOOGLE_CREDENTIALS** not working as a raw json string as described in the docs. 

## why
* As of 2025 this component cannot be deployed in its current latest version
* Go 1.x cannot be deployed after Feb 8, 2024
* And even if it could be deployed there is a bug with the version variable
* The **SSOSYNC_GOOGLE_CREDENTIALS** ENV variable read is not working as described

## references
* https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtimes-deprecated
* https://aws.amazon.com/blogs/compute/migrating-aws-lambda-functions-from-the-go1-x-runtime-to-the-custom-runtime-on-amazon-linux-2/
* `closes #16`

## extra info
**SSOSYNC_GOOGLE_CREDENTIALS** should have a value `/tmp/credentials.json`
**SSOSYNC_GOOGLE_CREDS_JSON** should exist in AWS ParamStore with the full content of Google's SA json.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new AWS SSM parameter to manage Google credentials for Lambda functions.

* **Improvements**
  * Lambda function environment variables now include Google credentials if configured.
  * Lambda runtime updated from Go to Python 3.12.
  * Lambda handler updated to use Python entry point.
  * Improved artifact packaging and ensured the binary is executable.

* **Chores**
  * Updated default version format for the ssosync version variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->