### PR TITLE
fix: Remove deprecated Terraform syntax

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -16,7 +16,7 @@ locals {
   download_artifact    = "ssosync.tar.gz"
 
   lambda_files     = fileset("${path.module}/dist", "*")
-  tar_file         = fileset("${path.module}", "${local.download_artifact}")
+  tar_file         = fileset(path.module, local.download_artifact)
   tar_file_content = [for f in local.tar_file : filebase64sha256("${path.module}/${f}")]
 
   file_content_map = local.enabled ? [


### PR DESCRIPTION
## Why

Deprecated HCL syntax triggers linting warnings and will eventually be removed in future Terraform versions. Cleaning these up improves code quality, maintainability, and ensures forward compatibility.

## What

Automated fixes applied via `tflint --fix` with the following rules enabled:

| Rule | Description | Example |
|------|-------------|---------|
| `terraform_deprecated_interpolation` | Remove unnecessary interpolation wrappers | `"${var.foo}"` → `var.foo` |
| `terraform_deprecated_index` | Replace legacy dot-index syntax | `list.0` → `list[0]` |
| `terraform_deprecated_lookup` | Replace deprecated `lookup()` calls | `lookup(map, key)` → `map[key]` |

## References

- [tflint terraform_deprecated_interpolation](https://github.com/terraform-linters/tflint-ruleset-terraform/blob/main/docs/rules/terraform_deprecated_interpolation.md)
- [tflint terraform_deprecated_index](https://github.com/terraform-linters/tflint-ruleset-terraform/blob/main/docs/rules/terraform_deprecated_index.md)
- [tflint terraform_deprecated_lookup](https://github.com/terraform-linters/tflint-ruleset-terraform/blob/main/docs/rules/terraform_deprecated_lookup.md)
- [Terraform: References to Named Values](https://developer.hashicorp.com/terraform/language/expressions/references)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved Terraform configuration syntax for enhanced code clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->