### PR TITLE
feat: switch to awslabs/ssosync v2.0+ (drop CloudPosse fork)

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -46,6 +46,15 @@ components:
           - "name='Acme Team'"
 ```
 
+### Secret Storage
+
+This component uses both SSM Parameter Store and Secrets Manager for different purposes:
+
+- **SSM Parameter Store** — source of truth for sensitive values, managed by ops. Terraform reads from SSM at apply time.
+- **Secrets Manager** — runtime secret store for the Lambda. Terraform creates/updates Secrets Manager secrets from the SSM values. At invocation time, ssosync v2.0+ reads config directly from Secrets Manager via its `configLambda()` code path, using unprefixed env vars (e.g. `GOOGLE_CREDENTIALS`, `SCIM_ENDPOINT`) as secret names.
+
+This approach avoids embedding the Google credentials JSON directly in Lambda environment variables, which would hit the 4 KB env var size limit for large service account keys.
+
 We recommend following a similar process to what the [AWS ssosync](https://github.com/awslabs/ssosync) documentation
 recommends.
 

--- a/src/README.md
+++ b/src/README.md
@@ -33,9 +33,11 @@ components:
         enabled: true
         name: ssosync
         google_admin_email: admin@acme.com
-        log_format: text
+        log_format: json
         log_level: warn
         schedule_expression: "rate(15 minutes)"
+        ssosync_url_prefix: "https://github.com/awslabs/ssosync/releases/download"
+        ssosync_version: "v2.3.7"
         # Filter the groups that will be synced and is optional (default: all groups)
         # This supports wild cards `*`
         google_group_match:
@@ -142,17 +144,6 @@ Use the names of the Groups now provisioned programmatically in the `aws-sso` co
 [aws-sso](../aws-sso/) component documentation to deploy the `aws-sso` component.
 
 ### FAQ
-
-#### Why is the tool forked by `Benbentwo`?
-
-The `awslabs` tool requires AWS Secrets Managers for the Google Credentials. However, we would prefer to use AWS SSM to
-store all credentials consistency and not require AWS Secrets Manager. Therefore we've created a Pull Request and will
-point to a fork until the PR is merged.
-
-Ref:
-
-- https://github.com/awslabs/ssosync/pull/133
-- https://github.com/awslabs/ssosync/issues/93
 
 #### What should I use for the Google Admin Email Address?
 

--- a/src/iam.tf
+++ b/src/iam.tf
@@ -24,6 +24,7 @@ data "aws_iam_policy_document" "ssosync_lambda_identity_center" {
       "identitystore:GetGroupMembershipId",
       "identitystore:DeleteGroupMembership",
       "identitystore:DeleteGroup",
+      "secretsmanager:DescribeSecret",
       "secretsmanager:GetSecretValue",
       "kms:Decrypt",
       "logs:PutLogEvents",

--- a/src/main.tf
+++ b/src/main.tf
@@ -1,11 +1,25 @@
 locals {
   # Version of ssosync to use
   version                    = var.ssosync_version
-  enabled                    = module.this.enabled
+  enabled = module.this.enabled
+
+  # SSM Parameter Store is the source of truth for sensitive values.
+  # Terraform reads these at apply time to populate Secrets Manager.
+  # At Lambda runtime, ssosync v2.0+ reads config from Secrets Manager
+  # using unprefixed env vars as secret names (configLambda() code path).
   google_credentials         = one(data.aws_ssm_parameter.google_credentials[*].value)
   scim_endpoint_url          = one(data.aws_ssm_parameter.scim_endpoint_url[*].value)
   scim_endpoint_access_token = one(data.aws_ssm_parameter.scim_endpoint_access_token[*].value)
   identity_store_id          = one(data.aws_ssm_parameter.identity_store_id[*].value)
+
+  secrets = local.enabled ? {
+    "${var.google_credentials_ssm_path}/google_credentials" = local.google_credentials
+    "${var.google_credentials_ssm_path}/google_admin"       = var.google_admin_email
+    "${var.google_credentials_ssm_path}/scim_endpoint"      = local.scim_endpoint_url
+    "${var.google_credentials_ssm_path}/scim_access_token"  = local.scim_endpoint_access_token
+    "${var.google_credentials_ssm_path}/identity_store_id"  = local.identity_store_id
+    "${var.google_credentials_ssm_path}/region"             = var.region
+  } : {}
 
   # ssosync v2.0+ dropped the Lambda_ prefix from release asset filenames.
   ssosync_artifact_url = "${var.ssosync_url_prefix}/${local.version}/ssosync_Linux_${var.architecture}.tar.gz"
@@ -121,21 +135,24 @@ resource "aws_lambda_function" "ssosync" {
 
   environment {
     variables = {
-      SSOSYNC_LOG_LEVEL               = var.log_level
-      SSOSYNC_LOG_FORMAT              = var.log_format
-      SSOSYNC_GOOGLE_CREDENTIALS_JSON = local.google_credentials
-      SSOSYNC_GOOGLE_ADMIN            = var.google_admin_email
-      SSOSYNC_SCIM_ENDPOINT           = local.scim_endpoint_url
-      SSOSYNC_SCIM_ACCESS_TOKEN       = local.scim_endpoint_access_token
-      SSOSYNC_REGION                  = var.region
-      SSOSYNC_IDENTITY_STORE_ID       = local.identity_store_id
-      SSOSYNC_USER_MATCH              = join(",", var.google_user_match)
-      SSOSYNC_GROUP_MATCH             = join(",", var.google_group_match)
-      SSOSYNC_SYNC_METHOD             = var.sync_method
-      SSOSYNC_IGNORE_GROUPS           = var.ignore_groups
-      SSOSYNC_IGNORE_USERS            = var.ignore_users
-      SSOSYNC_INCLUDE_GROUPS          = var.include_groups
-      SSOSYNC_LOAD_ASM_SECRETS        = false
+      # ssosync v2.0+ Lambda mode (configLambda): unprefixed env vars are
+      # Secrets Manager secret names, resolved at invocation time.
+      GOOGLE_CREDENTIALS = "${var.google_credentials_ssm_path}/google_credentials"
+      GOOGLE_ADMIN       = "${var.google_credentials_ssm_path}/google_admin"
+      SCIM_ENDPOINT      = "${var.google_credentials_ssm_path}/scim_endpoint"
+      SCIM_ACCESS_TOKEN  = "${var.google_credentials_ssm_path}/scim_access_token"
+      IDENTITY_STORE_ID  = "${var.google_credentials_ssm_path}/identity_store_id"
+      REGION             = "${var.google_credentials_ssm_path}/region"
+
+      # Non-sensitive config read via Viper (SSOSYNC_ prefix).
+      SSOSYNC_LOG_LEVEL      = var.log_level
+      SSOSYNC_LOG_FORMAT     = var.log_format
+      SSOSYNC_SYNC_METHOD    = var.sync_method
+      SSOSYNC_USER_MATCH     = join(",", var.google_user_match)
+      SSOSYNC_GROUP_MATCH    = join(",", var.google_group_match)
+      SSOSYNC_IGNORE_GROUPS  = var.ignore_groups
+      SSOSYNC_IGNORE_USERS   = var.ignore_users
+      SSOSYNC_INCLUDE_GROUPS = var.include_groups
     }
   }
 
@@ -143,6 +160,22 @@ resource "aws_lambda_function" "ssosync" {
     replace_triggered_by = [archive_file.lambda]
   }
   depends_on = [null_resource.extract_my_tgz, archive_file.lambda]
+}
+
+# Secrets Manager secrets — values sourced from SSM at apply time.
+# ssosync's Lambda handler resolves these by name at invocation time.
+resource "aws_secretsmanager_secret" "ssosync" {
+  for_each = local.secrets
+
+  name                    = each.key
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "ssosync" {
+  for_each = local.secrets
+
+  secret_id     = aws_secretsmanager_secret.ssosync[each.key].id
+  secret_string = each.value
 }
 
 resource "aws_cloudwatch_event_rule" "ssosync" {

--- a/src/main.tf
+++ b/src/main.tf
@@ -1,18 +1,14 @@
 locals {
   # Version of ssosync to use
-  # We forked it because we use SSM Parameters to load the env vars
-  # The issue has been tracked several places but never merged.
-  # https://github.com/awslabs/ssosync/issues/93
-  # https://github.com/awslabs/ssosync/issues/180
-  version = var.ssosync_version
-  # -----------------------------------------------------------
+  version                    = var.ssosync_version
   enabled                    = module.this.enabled
   google_credentials         = one(data.aws_ssm_parameter.google_credentials[*].value)
   scim_endpoint_url          = one(data.aws_ssm_parameter.scim_endpoint_url[*].value)
   scim_endpoint_access_token = one(data.aws_ssm_parameter.scim_endpoint_access_token[*].value)
   identity_store_id          = one(data.aws_ssm_parameter.identity_store_id[*].value)
 
-  ssosync_artifact_url = "${var.ssosync_url_prefix}/${local.version}/Lambda_ssosync_Linux_${var.architecture}.tar.gz"
+  # ssosync v2.0+ dropped the Lambda_ prefix from release asset filenames.
+  ssosync_artifact_url = "${var.ssosync_url_prefix}/${local.version}/ssosync_Linux_${var.architecture}.tar.gz"
   download_artifact    = "ssosync.tar.gz"
 
   lambda_files     = fileset("${path.module}/dist", "*")
@@ -79,7 +75,8 @@ resource "null_resource" "extract_my_tgz" {
   count = local.enabled ? 1 : 0
 
   provisioner "local-exec" {
-    command = "tar -xzf ${local.download_artifact} -C dist"
+    # ssosync v2.0+ names the binary "ssosync"; provided.al2023 requires "bootstrap".
+    command = "tar -xzf ${local.download_artifact} -C dist && mv dist/ssosync dist/bootstrap"
   }
   // We want to re-extract the tar.gz when the tar.gz changes or the dist folder changes
   triggers = {

--- a/src/main.tf
+++ b/src/main.tf
@@ -1,6 +1,6 @@
 locals {
   # Version of ssosync to use
-  version                    = var.ssosync_version
+  version = var.ssosync_version
   enabled = module.this.enabled
 
   # SSM Parameter Store is the source of truth for sensitive values.

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -34,13 +34,13 @@ variable "log_format" {
 variable "ssosync_url_prefix" {
   type        = string
   description = "URL prefix for ssosync binary"
-  default     = "https://github.com/cloudposse/ssosync/releases/download"
+  default     = "https://github.com/awslabs/ssosync/releases/download"
 }
 
 variable "ssosync_version" {
   type        = string
   description = "Version of ssosync to use"
-  default     = "v3.0.0"
+  default     = "v2.3.7"
 }
 
 variable "architecture" {


### PR DESCRIPTION
## What
- Switch default `ssosync_url_prefix` from `cloudposse/ssosync` to `awslabs/ssosync`; default version `v2.3.7`
- Remove `Lambda_` prefix from release asset URL (dropped in awslabs v2.0+)
- Rename extracted binary `ssosync` → `bootstrap` after extraction (required by `provided.al2023` runtime)
- Switch Lambda config to Secrets Manager mode (awslabs v2.0+ `configLambda()` code path)
  - Terraform reads SSM at apply time and creates/updates Secrets Manager secrets
  - Lambda env vars are secret names, not values; ssosync resolves them at invocation time
  - Removes `SSOSYNC_LOAD_ASM_SECRETS` and embedded credential env vars (`SSOSYNC_GOOGLE_CREDENTIALS_JSON`, etc.)
- Add `secretsmanager:DescribeSecret` IAM permission (called before `GetSecretValue` in Lambda mode)
- Remove stale FAQ entry about the Benbentwo fork
- Add "Secret Storage" section to README explaining SSM + Secrets Manager dual usage

## Why
- awslabs/ssosync v2.0+ now supports Lambda mode natively via `configLambda()`, reading config from Secrets Manager at invocation time — the original reason for the CloudPosse fork no longer exists
- Switching to the official upstream removes the maintenance burden of tracking a fork
- Embedding Google credentials JSON directly as an env var hits the Lambda 4 KB env var size limit for real service account keys — Secrets Manager sidesteps this entirely
- The `provided.al2023` runtime requires the entrypoint binary named `bootstrap`; awslabs v2.0+ ships the binary as `ssosync` so a rename is needed after extraction

## Breaking Change
The Lambda env vars have changed from embedded credential values to Secrets Manager secret names. Existing deployments must complete the following steps before upgrading:

1. **Update `ssosync_url_prefix` and `ssosync_version`** in your stack config. The defaults now point to `awslabs/ssosync` — if you were previously pinned to the CloudPosse fork, the new Lambda mode config will not be compatible with it:
   ```yaml
   ssosync_url_prefix: "https://github.com/awslabs/ssosync/releases/download"
   ssosync_version: "v2.3.7"
   ```

2. **Ensure the following SSM parameters exist** (using the default `google_credentials_ssm_path = "/ssosync"`):

   | SSM Parameter | Description |
   |---|---|
   | `/ssosync/google_credentials` | Google service account credentials JSON |
   | `/ssosync/scim_endpoint_url` | AWS SSO SCIM endpoint URL |
   | `/ssosync/scim_endpoint_access_token` | AWS SSO SCIM access token |
   | `/ssosync/identity_store_id` | AWS Identity Store ID (format: `d-xxxxxxxxxx`) |

3. **Run `terraform apply`** — Terraform will read the SSM values, create the Secrets Manager secrets, and update the Lambda env vars in a single apply.

No manual Secrets Manager setup is required; Terraform handles the migration automatically as long as the SSM parameters are in place.

## Ref
- https://github.com/awslabs/ssosync/releases/tag/v2.0.0