### PR TITLE
fix: use bare env var names for non-sensitive Lambda config

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -144,15 +144,17 @@ resource "aws_lambda_function" "ssosync" {
       IDENTITY_STORE_ID  = "${var.google_credentials_ssm_path}/identity_store_id"
       REGION             = "${var.google_credentials_ssm_path}/region"
 
-      # Non-sensitive config read via Viper (SSOSYNC_ prefix).
-      SSOSYNC_LOG_LEVEL      = var.log_level
-      SSOSYNC_LOG_FORMAT     = var.log_format
-      SSOSYNC_SYNC_METHOD    = var.sync_method
-      SSOSYNC_USER_MATCH     = join(",", var.google_user_match)
-      SSOSYNC_GROUP_MATCH    = join(",", var.google_group_match)
-      SSOSYNC_IGNORE_GROUPS  = var.ignore_groups
-      SSOSYNC_IGNORE_USERS   = var.ignore_users
-      SSOSYNC_INCLUDE_GROUPS = var.include_groups
+      # Non-sensitive config: configLambda() reads these via os.LookupEnv with bare names
+      # (no SSOSYNC_ prefix), bypassing Viper. Using the SSOSYNC_ prefix causes these
+      # values to be silently ignored, e.g. GROUP_MATCH defaults to "*" (all groups).
+      LOG_LEVEL      = var.log_level
+      LOG_FORMAT     = var.log_format
+      SYNC_METHOD    = var.sync_method
+      USER_MATCH     = join(",", var.google_user_match)
+      GROUP_MATCH    = join(",", var.google_group_match)
+      IGNORE_GROUPS  = var.ignore_groups
+      IGNORE_USERS   = var.ignore_users
+      INCLUDE_GROUPS = var.include_groups
     }
   }
 


### PR DESCRIPTION
## What
- Remove the `SSOSYNC_` prefix from non-sensitive Lambda environment variables (`LOG_LEVEL`, `LOG_FORMAT`, `USER_MATCH`, `GROUP_MATCH`, `SYNC_METHOD`, `IGNORE_GROUPS`, `IGNORE_USERS`, `INCLUDE_GROUPS`)

## Why
- When ssosync runs as a Lambda (custom runtime `provided.al2023`), the `configLambda()` function reads all config fields using `os.LookupEnv()` directly with bare, unprefixed names — it does not go through Viper's `SetEnvPrefix("ssosync")` mechanism
- Setting `SSOSYNC_GROUP_MATCH` (for example) causes the value to be silently ignored; the filter defaults to `*` (all groups), as reported in the Lambda logs: `level=info msg="get google groups" queryGroup="*"`
- Confirmed by community user: removing the `SSOSYNC_` prefix fixes the behavior

## Ref
- Reported by Gerry Laracuente in SweetOps Slack
- Related: cloudposse-terraform-components/aws-ssosync#47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Environment variable naming conventions have been updated. Non-sensitive configuration settings now use unprefixed names, while sensitive credentials retain the `SSOSYNC_` prefix for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->